### PR TITLE
Add draft of schema file

### DIFF
--- a/generated-schema.json
+++ b/generated-schema.json
@@ -1,0 +1,244 @@
+{
+  "$defs": {
+    "ChannelEnum": {
+      "enum": [
+        "default",
+        "esr",
+        "release",
+        "beta",
+        "daily"
+      ],
+      "title": "ChannelEnum",
+      "type": "string"
+    },
+    "Notification": {
+      "properties": {
+        "id": {
+          "format": "uuid",
+          "title": "Id",
+          "type": "string"
+        },
+        "start_at": {
+          "format": "date-time",
+          "title": "Start At",
+          "type": "string"
+        },
+        "end_at": {
+          "format": "date-time",
+          "title": "End At",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "URL": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "maxLength": 2083,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Url"
+        },
+        "CTA": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cta"
+        },
+        "severity": {
+          "$ref": "#/$defs/SeverityEnum"
+        },
+        "type": {
+          "$ref": "#/$defs/TypeEnum"
+        },
+        "targeting": {
+          "$ref": "#/$defs/Targeting"
+        }
+      },
+      "required": [
+        "id",
+        "start_at",
+        "end_at",
+        "title",
+        "description",
+        "severity",
+        "type",
+        "targeting"
+      ],
+      "title": "Notification",
+      "type": "object"
+    },
+    "OperatingSystemEnum": {
+      "enum": [
+        "win",
+        "macosx",
+        "linux",
+        "freebsd",
+        "openbsd",
+        "netbsd",
+        "solaris",
+        "other"
+      ],
+      "title": "OperatingSystemEnum",
+      "type": "string"
+    },
+    "Profile": {
+      "properties": {
+        "locales": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Locales"
+        },
+        "versions": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Versions"
+        },
+        "channels": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/ChannelEnum"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Channels"
+        },
+        "operating_systems": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/OperatingSystemEnum"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Operating Systems"
+        }
+      },
+      "title": "Profile",
+      "type": "object"
+    },
+    "SeverityEnum": {
+      "enum": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "title": "SeverityEnum",
+      "type": "integer"
+    },
+    "Targeting": {
+      "properties": {
+        "percent_chance": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Percent Chance"
+        },
+        "exclude": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Profile"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude"
+        },
+        "include": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Profile"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Include"
+        }
+      },
+      "title": "Targeting",
+      "type": "object"
+    },
+    "TypeEnum": {
+      "enum": [
+        "donation",
+        "message",
+        "security",
+        "blog"
+      ],
+      "title": "TypeEnum",
+      "type": "string"
+    }
+  },
+  "items": {
+    "$ref": "#/$defs/Notification"
+  },
+  "title": "NotificationSchema",
+  "type": "array"
+}

--- a/schema.json
+++ b/schema.json
@@ -13,12 +13,12 @@
       "start_at": {
         "type": "string",
         "format": "date-time",
-        "description": "Timestamp after which Thunderbird will show the event after startup."
+        "description": "UTC Timestamp after which Thunderbird will show the event after startup."
       },
       "end_at": {
         "type": "string",
         "format": "date-time",
-        "description": "Timestamp after which Thunderbird will never show the event, even if it has never been shown to the user."
+        "description": "UTC Timestamp after which Thunderbird will never show the event, even if it has never been shown to the user."
       },
       "title": {
         "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -31,7 +31,7 @@
       "URL": {
         "type": "string",
         "format": "uri",
-        "description": "URL to load, if any."
+        "description": "URL to open from the CTA, if any."
       },
       "CTA": {
         "type": "string",
@@ -54,10 +54,16 @@
             "maximum": 100
           },
           "exclude": {
-            "$ref": "#/definitions/profile"
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/profile"
+            }
           },
           "include": {
-            "$ref": "#/definitions/profile"
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/profile"
+            }
           }
         }
       }
@@ -107,7 +113,8 @@
               "freebsd",
               "openbsd",
               "netbsd",
-              "solaris"
+              "solaris",
+              "other"
             ],
             "description": "Operating System"
           }

--- a/schema.json
+++ b/schema.json
@@ -99,7 +99,7 @@
         "channels": {
           "type": "array",
           "items": {
-            "enum": ["esr", "release", "beta", "daily"],
+            "enum": ["default", "esr", "release", "beta", "daily"],
             "description": "Channel"
           }
         },

--- a/schema.json
+++ b/schema.json
@@ -107,8 +107,8 @@
           "type": "array",
           "items": {
             "enum": [
-              "windows",
-              "macos",
+              "win",
+              "macosx",
               "linux",
               "freebsd",
               "openbsd",

--- a/schema.json
+++ b/schema.json
@@ -1,62 +1,60 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Thunderbird In-App Notifications",
   "type": "array",
-  "items": [
-    {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "format": "uuid",
-          "description": "Unique ID set by the server"
-        },
-        "start_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Timestamp after which Thunderbird will show the event after startup."
-        },
-        "end_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Timestamp after which Thunderbird will never show the event, even if it has never been shown to the user."
-        },
-        "title": {
-          "type": "string",
-          "description": "Short sentence describing the event which will be displayed in the Thunderbird UI."
-        },
-        "description": {
-          "type": "string",
-          "description": "A short paragraph that can contain HTML and will be displayed in the Thunderbird UI."
-        },
-        "URL": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL to load, if any."
-        },
-        "CTA": {
-          "type": "string",
-          "description": "Link text to show for the URL."
-        },
-        "severity": {
-          "enum": [1, 2, 3, 4, 5],
-          "description": "Severity level, where 1 is the most important/urgent and 5 is the least."
-        },
-        "type": {
-          "enum": ["donation", "message", "security", "blog"],
-          "description": "Category of notification."
-        }
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Unique ID set by the server"
       },
-      "required": [
-        "id",
-        "start_at",
-        "end_at",
-        "title",
-        "description",
-        "severity",
-        "type"
-      ],
-      "dependentRequired": { "CTA": ["URL"] }
-    }
-  ]
+      "start_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Timestamp after which Thunderbird will show the event after startup."
+      },
+      "end_at": {
+        "type": "string",
+        "format": "date-time",
+        "description": "Timestamp after which Thunderbird will never show the event, even if it has never been shown to the user."
+      },
+      "title": {
+        "type": "string",
+        "description": "Short sentence describing the event which will be displayed in the Thunderbird UI."
+      },
+      "description": {
+        "type": "string",
+        "description": "A short paragraph that can contain HTML and will be displayed in the Thunderbird UI."
+      },
+      "URL": {
+        "type": "string",
+        "format": "uri",
+        "description": "URL to load, if any."
+      },
+      "CTA": {
+        "type": "string",
+        "description": "Link text to show for the URL."
+      },
+      "severity": {
+        "enum": [1, 2, 3, 4, 5],
+        "description": "Severity level, where 1 is the most important/urgent and 5 is the least."
+      },
+      "type": {
+        "enum": ["donation", "message", "security", "blog"],
+        "description": "Category of notification."
+      }
+    },
+    "required": [
+      "id",
+      "start_at",
+      "end_at",
+      "title",
+      "description",
+      "severity",
+      "type"
+    ],
+    "dependentRequired": { "CTA": ["URL"] }
+  }
 }

--- a/schema.json
+++ b/schema.json
@@ -55,7 +55,8 @@
         "description",
         "severity",
         "type"
-      ]
+      ],
+      "dependentRequired": { "CTA": ["URL"] }
     }
   ]
 }

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Thunderbird In-App Notifications",
+  "type": "array",
+  "items": [
+    {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique ID set by the server"
+        },
+        "start_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp after which Thunderbird will show the event after startup."
+        },
+        "end_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp after which Thunderbird will never show the event, even if it has never been shown to the user."
+        },
+        "title": {
+          "type": "string",
+          "description": "Short sentence describing the event which will be displayed in the Thunderbird UI."
+        },
+        "description": {
+          "type": "string",
+          "description": "A short paragraph that can contain HTML and will be displayed in the Thunderbird UI."
+        },
+        "URL": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to load, if any."
+        },
+        "CTA": {
+          "type": "string",
+          "description": "Link text to show for the URL."
+        },
+        "severity": {
+          "enum": [1, 2, 3, 4, 5],
+          "description": "Severity level, where 1 is the most important/urgent and 5 is the least."
+        },
+        "type": {
+          "enum": ["donation", "message", "security", "blog"],
+          "description": "Category of notification."
+        }
+      },
+      "required": [
+        "id",
+        "start_at",
+        "end_at",
+        "title",
+        "description",
+        "severity",
+        "type"
+      ]
+    }
+  ]
+}

--- a/schema.json
+++ b/schema.json
@@ -44,6 +44,22 @@
       "type": {
         "enum": ["donation", "message", "security", "blog"],
         "description": "Category of notification."
+      },
+      "targeting": {
+        "type": "object",
+        "properties": {
+          "percent_chance": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "exclude": {
+            "$ref": "#/definitions/profile"
+          },
+          "include": {
+            "$ref": "#/definitions/profile"
+          }
+        }
       }
     },
     "required": [
@@ -53,8 +69,50 @@
       "title",
       "description",
       "severity",
-      "type"
+      "type",
+      "targeting"
     ],
     "dependentRequired": { "CTA": ["URL"] }
+  },
+  "definitions": {
+    "profile": {
+      "type": "object",
+      "properties": {
+        "locales": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "enum": ["esr", "release", "beta", "daily"],
+            "description": "Channel"
+          }
+        },
+        "operating_systems": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "windows",
+              "macos",
+              "linux",
+              "freebsd",
+              "openbsd",
+              "netbsd",
+              "solaris"
+            ],
+            "description": "Operating System"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #1 

The new `schema.json` includes the fields mentioned in the [tech spec](https://docs.google.com/document/d/1_3H2QGJhdW1Y_HESfrH7hzFDSXGWYZouiLf7Ru4Gs0g/edit) as well as:
* descriptions of each field
* a list of required fields

Please let me know if anything is missing or needs improvement!

---

Update: now includes a version of the schema generated by the pydantic model (from #5).
With the exception of the [`dependantRequired` key](#7) , it is equivalent to the schema.json introduced by this PR.