### PR TITLE
Add GH action: convert yaml to json

### DIFF
--- a/.github/workflows/convert-yaml-to-json.yml
+++ b/.github/workflows/convert-yaml-to-json.yml
@@ -23,4 +23,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run python script
         run: |
-          python convert-yaml.py yaml_notifications json_notifications
+          python convert-yaml.py test/data/yaml test/data/json

--- a/.github/workflows/convert-yaml-to-json.yml
+++ b/.github/workflows/convert-yaml-to-json.yml
@@ -1,11 +1,9 @@
 name: convert-yaml-to-json
 
 on:
-  [push]
-  # push:
-  #   branches: ["main"]
-  # pull_request:
-  #   branches: ["main"]
+  push:
+    paths:
+      - "yaml/**.yaml"
 
 jobs:
   build:

--- a/.github/workflows/convert-yaml-to-json.yml
+++ b/.github/workflows/convert-yaml-to-json.yml
@@ -1,0 +1,26 @@
+name: convert-yaml-to-json
+
+on:
+  [push]
+  # push:
+  #   branches: ["main"]
+  # pull_request:
+  #   branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run python script
+        run: |
+          python convert-yaml.py yaml_notifications json_notifications

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -23,12 +23,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run convert-yaml.py
-        run: |
-          if [ -d "yaml" ] && [ "$(ls -A yaml/*.yaml 2>/dev/null)" ]; then
-            python convert-yaml.py yaml json
-          else
-            echo "No YAML files to process."
-          fi
+        run: python convert-yaml.py yaml json
 
       - name: Upload JSON artifacts for validation
         uses: actions/upload-artifact@v4

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -6,19 +6,66 @@ on:
       - "yaml/**.yaml"
 
 jobs:
-  convert:
+  convert-yaml:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
       - name: Run python script
         run: |
-          python convert-yaml.py yaml json
+          if [ -d "yaml" ] && [ "$(ls -A yaml/*.yaml 2>/dev/null)" ]; then
+            python convert-yaml.py yaml json
+          else
+            echo "No YAML files to process."
+          fi
+
+      - name: Upload JSON artifacts for validation
+        uses: actions/upload-artifact@v4
+        with:
+          name: json-files
+          path: json/*.json
+
+  validate-json:
+    needs: convert-yaml
+    uses: ./.github/workflows/validate.yml
+    with:
+      should_download: true
+
+  commit-json:
+    runs-on: ubuntu-latest
+    needs: validate-json
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for validation success and file changes
+        run: |
+          if [ "${{ needs.validate-json.outputs.is_valid }}" != "true" ]; then
+            echo "JSON is not valid. Skipping commit."
+            echo "NO_COMMIT=true" >> $GITHUB_ENV
+          elif git diff --quiet; then
+            echo "No changes to commit"
+            echo "NO_COMMIT=true" >> $GITHUB_ENV
+          fi
+
+      - name: Commit changes
+        if: ${{ env.NO_COMMIT != 'true' }}
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add .
+          git commit -m "Automated commit by GitHub Action"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -21,4 +21,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run python script
         run: |
-          python convert-yaml.py test/data/yaml test/data/json
+          python convert-yaml.py yaml json

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -6,7 +6,7 @@ on:
       - "yaml/**.yaml"
 
 jobs:
-  build:
+  convert:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -22,7 +22,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run python script
+      - name: Run convert-yaml.py
         run: |
           if [ -d "yaml" ] && [ "$(ls -A yaml/*.yaml 2>/dev/null)" ]; then
             python convert-yaml.py yaml json

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,18 +2,35 @@ name: validate-json
 
 on:
   workflow_call:
-  push:
-    branches: ["*"]
+    inputs:
+      should_download:
+        description: "Download JSON artifacts if called by another workflow?"
+        type: boolean
+    outputs:
+      is_valid:
+        description: "Is the JSON valid?"
+        value: ${{ jobs.validate.outputs.is_valid}}
+
   pull_request:
     branches: ["*"]
+
   workflow_dispatch:
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    outputs:
+      is_valid: ${{ steps.save_state.outputs.is_valid}}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download JSON artifacts # if called by another workflow
+        if: ${{ inputs.should_download }}
+        uses: actions/download-artifact@v4
+        with:
+          name: json-files
+          path: json
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -33,5 +50,6 @@ jobs:
           fi
 
       - name: Save state
+        id: save_state
         if: steps.validate_json.conclusion == 'success'
-        run: echo "JV_COMMAND_SUCCESS=true" >> $GITHUB_ENV
+        run: echo "is_valid=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,27 +1,37 @@
 name: validate-json
 
 on:
-  [push]
-  # push:
-  #   branches: ["main"]
-  # pull_request:
-  #   branches: ["main"]
+  workflow_call:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ">=1.22.4"
+
       - name: Install dependencies
         run: go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest
+
       - name: Validate JSON files
+        id: validate_json
         run: |
           if [ -d "json" ] && [ "$(ls -A json/*.json 2>/dev/null)" ]; then
             jv schema.json json/*.json
           else
             echo "No JSON files to process."
           fi
+
+      - name: Save state
+        if: steps.validate_json.conclusion == 'success'
+        run: echo "JV_COMMAND_SUCCESS=true" >> $GITHUB_ENV

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,22 +32,23 @@ jobs:
           name: json-files
           path: json
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: ">=1.22.4"
 
-      - name: Install dependencies
+      - name: Install Go dependencies
         run: go install github.com/santhosh-tekuri/jsonschema/cmd/jv@latest
 
       - name: Validate JSON files
         id: validate_json
-        run: |
-          if [ -d "json" ] && [ "$(ls -A json/*.json 2>/dev/null)" ]; then
-            jv schema.json json/*.json
-          else
-            echo "No JSON files to process."
-          fi
+        run: python validate-json.py schema.json json
 
       - name: Save state
         id: save_state

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          # cache: "pip"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
+          # cache: "pip"
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/convert-yaml.py
+++ b/convert-yaml.py
@@ -53,6 +53,7 @@ class YAMLtoJSONConverter:
       should_write = args.overwrite or not does_exist
       if should_write:
         with open(json_file_path, "w") as f:
+          print(f'Writing {json_file_path}')
           self.write_schema_as_json(schema, f)
 
 def main():

--- a/convert-yaml.py
+++ b/convert-yaml.py
@@ -41,7 +41,12 @@ class YAMLtoJSONConverter:
 
   def convert(self):
     """Reads, validates YAML files from a directory and writes JSON files to separate directory."""
-    for yaml_file_path in self.get_yaml_file_paths():
+    yaml_file_paths = self.get_yaml_file_paths()
+    if not yaml_file_paths:
+        print("No YAML files to process.")
+        return
+
+    for yaml_file_path in yaml_file_paths:
       schema = NotificationSchema.from_yaml(yaml_file_path)
 
       json_file_name = self.generate_json_file_name(yaml_file_path)

--- a/json/example2.json
+++ b/json/example2.json
@@ -23,7 +23,8 @@
         {
           "locales": [],
           "versions": [],
-          "channels": []
+          "channels": [],
+          "operating_systems": []
         }
       ]
     }
@@ -52,7 +53,8 @@
         {
           "locales": [],
           "versions": [],
-          "channels": []
+          "channels": [],
+          "operating_systems": []
         }
       ]
     }

--- a/json/example2.json
+++ b/json/example2.json
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "f103c749-9932-48bb-8f61-2e8ed2beacc3",
+    "start_at": "2012-03-29T10:05:45-06:00",
+    "end_at": "2012-03-29T10:05:45-06:00",
+    "title": "hello user - this needs translation",
+    "description": "lorem ipsum user - this needs translation",
+    "CTA": "lorem ipsum user - this needs translation",
+    "URL": "https://thunderbird.net",
+    "severity": 5,
+    "type": "donation",
+    "targeting": {
+      "percent_chance": 10,
+      "exclude": [
+        {
+          "locales": [],
+          "versions": [],
+          "channels": [],
+          "operating_systems": []
+        }
+      ],
+      "include": [
+        {
+          "locales": [],
+          "versions": [],
+          "channels": []
+        }
+      ]
+    }
+  },
+  {
+    "id": "f103c749-9932-48bb-8f61-2e8ed2beacc3",
+    "start_at": "2012-03-29T10:05:45-06:00",
+    "end_at": "2024-05-03T15:49:20.331Z",
+    "title": "hello user - this needs translation",
+    "description": "lorem ipsum user - this needs translation",
+    "CTA": "lorem ipsum user - this needs translation",
+    "URL": "https://thunderbird.net",
+    "severity": 5,
+    "type": "donation",
+    "targeting": {
+      "percent_chance": 10,
+      "exclude": [
+        {
+          "locales": [],
+          "versions": [],
+          "channels": [],
+          "operating_systems": []
+        }
+      ],
+      "include": [
+        {
+          "locales": [],
+          "versions": [],
+          "channels": []
+        }
+      ]
+    }
+  }
+]

--- a/test/data/yaml/example.yaml
+++ b/test/data/yaml/example.yaml
@@ -1,0 +1,41 @@
+---
+- id: f103c749-9932-48bb-8f61-2e8ed2beacc3
+  start_at: "2012-03-29T10:05:45-06:00"
+  end_at: "2024-05-03T15:49:20.331Z"
+  title: hello user - this needs translation
+  description: lorem ipsum user - this needs translation
+  CTA: lorem ipsum user - this needs translation
+  URL: https://thunderbird.net
+  severity: 5
+  type: donation
+  targeting:
+    percent_chance: 100
+    exclude:
+      - locales: []
+        versions: []
+        channels: []
+        operating_systems: []
+    include:
+      - locales: []
+        versions: []
+        channels: []
+- id: f103c749-9932-48bb-8f61-2e8ed2beacc3
+  start_at: "2024-05-03T15:49:20.331Z"
+  end_at: "2024-05-03T15:49:20.331Z"
+  title: hello user - this needs translation
+  description: lorem ipsum user - this needs translation
+  CTA: lorem ipsum user - this needs translation
+  URL: https://thunderbird.net
+  severity: 5
+  type: donation
+  targeting:
+    percent_chance: 10
+    exclude:
+      - locales: []
+        versions: []
+        channels: []
+        operating_systems: []
+    include:
+      - locales: []
+        versions: []
+        channels: []

--- a/validate-json.py
+++ b/validate-json.py
@@ -21,7 +21,6 @@ class JSONValidator:
 
   def validate(self):
     json_files = [f for f in os.listdir(self.json_dir) if f.endswith('.json')]
-    print(json_files)
     if not json_files:
         print("No JSON files to process.")
         return 0  # Exit successfully if no JSON files are found
@@ -33,7 +32,7 @@ class JSONValidator:
       print('Validation command completed successfully')
       return 0
     except subprocess.CalledProcessError as e:
-      print(f'Error running validation command: {e.stderr}', file=sys.stderr)
+      print(f'Error running validation command: {e.stdout}', file=sys.stdout)
       return 1
 
 def main():

--- a/validate-json.py
+++ b/validate-json.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(description='Validate JSON schema and JSON files for Thunderbird notifications.')
+parser.add_argument('schema_file', type=str, help='The schema file to validate against.')
+parser.add_argument('json_dir', type=str, help='The directory containing JSON files.')
+args = parser.parse_args()
+
+class JSONValidator:
+  def __init__(self, schema_file, json_dir):
+    self.schema_file = schema_file
+    self.json_dir = json_dir
+
+    if not os.path.isfile(self.schema_file):
+      raise ValueError(f'Argument for schema file "{schema_file}" was not found.')
+
+    if not os.path.isdir(self.json_dir):
+      raise ValueError(f'Argument for json_dir "{self.json_dir}" is not a directory')
+
+  def validate(self):
+    json_files = [f for f in os.listdir(self.json_dir) if f.endswith('.json')]
+    print(json_files)
+    if not json_files:
+        print("No JSON files to process.")
+        return 0  # Exit successfully if no JSON files are found
+
+    command = ['jv', self.schema_file] + [os.path.join(self.json_dir, f) for f in json_files]
+
+    try:
+      result = subprocess.run(command, check=True, stdout=subprocess.PIPE,  stderr=subprocess.PIPE, text=True)
+      print('Validation command completed successfully')
+      return 0
+    except subprocess.CalledProcessError as e:
+      print(f'Error running validation command: {e.stderr}', file=sys.stderr)
+      return 1
+
+def main():
+  if len(sys.argv) < 3 or len(sys.argv) > 4:
+      parser.print_help()
+      sys.exit(1)
+
+  validator = JSONValidator(args.schema_file, args.json_dir)
+  exit_code = validator.validate()
+  sys.exit(exit_code)
+
+if __name__ == "__main__":
+  main()
+

--- a/yaml/example.yaml
+++ b/yaml/example.yaml
@@ -1,0 +1,41 @@
+---
+- id: f103c749-9932-48bb-8f61-2e8ed2beacc3
+  start_at: "2012-03-29T10:05:45-06:00"
+  end_at: "2024-05-03T15:49:20.331Z"
+  title: hello user - this needs translation
+  description: lorem ipsum user - this needs translation
+  CTA: lorem ipsum user - this needs translation
+  URL: https://thunderbird.net
+  severity: 5
+  type: donation
+  targeting:
+    percent_chance: 100
+    exclude:
+      - locales: []
+        versions: []
+        channels: []
+        operating_systems: []
+    include:
+      - locales: []
+        versions: []
+        channels: []
+- id: f103c749-9932-48bb-8f61-2e8ed2beacc3
+  start_at: "2024-05-03T15:49:20.331Z"
+  end_at: "2024-05-03T15:49:20.331Z"
+  title: hello user - this needs translation
+  description: lorem ipsum user - this needs translation
+  CTA: lorem ipsum user - this needs translation
+  URL: https://thunderbird.net
+  severity: 5
+  type: donation
+  targeting:
+    percent_chance: 10
+    exclude:
+      - locales: []
+        versions: []
+        channels: []
+        operating_systems: []
+    include:
+      - locales: []
+        versions: []
+        channels: []

--- a/yaml/example.yaml
+++ b/yaml/example.yaml
@@ -19,6 +19,7 @@
       - locales: []
         versions: []
         channels: []
+        operating_systems: []
 - id: f103c749-9932-48bb-8f61-2e8ed2beacc3
   start_at: "2024-05-03T15:49:20.331Z"
   end_at: "2024-05-03T15:49:20.331Z"
@@ -39,3 +40,4 @@
       - locales: []
         versions: []
         channels: []
+        operating_systems: []


### PR DESCRIPTION
Closes #3
Closes #8 

This PR:
* Runs the yaml to json conversion
* Validates existing json and any new json produced by the conversion
* If all json is valid, commit new json to repo

Changes to the `validate` workflow were necessary since it is called from the `convert` workflow:
* Makes the `validate` workflow reusable, but retains standalone functionality
* Adds inputs and outputs to `validate` 
  * the `should_download` input tells `validate` to download the JSON artifacts produced during the GH action
  * the `is_valid` output contains the status of the validation (whether all json files were valid)
* Per feedback, a python script now wraps the JSON validation command line tool

Tested locally using [nektos/act](https://github.com/nektos/act):
* `act pull_request` simulates a PR
  * This tests the `validate` workflow in standalone mode
* `act push --artifact-server-path /tmp` simulates a push
  * This is for testing the `convert` workflow (which calls `validate` before attempting to commit)

Note: only partially tested on GitHub. (This PR includes an example JSON file that passes validation.) #13 has been created to address this.