### PR TITLE
Updates gh action to use manually written JSON schema

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Validate JSON files
         run: |
           if [ -d "json" ] && [ "$(ls -A json/*.json 2>/dev/null)" ]; then
-            jv snapshot-schema.json json/*.json
+            jv schema.json json/*.json
           else
             echo "No JSON files to process."
           fi


### PR DESCRIPTION
Closes #11 

The manually written schema is [preferred](https://github.com/thunderbird/thunderbird-notifications/pull/2#issuecomment-2157786392), as it captures more nuances that the generated does not.

This PR changes the gh action to use it instead of one generated by pydantic.