### PR TITLE
Run convert-to-yaml on push to main and on pull requests

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -2,8 +2,12 @@ name: convert-yaml-to-json
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "yaml/**.yaml"
+  pull_request:
+    branches: ["*"]
 
 jobs:
   convert-yaml:


### PR DESCRIPTION
Closes #14

Per [this conversation](https://github.com/thunderbird/thunderbird-notifications/pull/9#discussion_r1678103209), we will run the convert-to-yaml workflow on:
- push to `main` if there are changes to the yaml files
- any pull requests