### PR TITLE
Add upgrade notification for May 2025 (Fixes #59)

### DIFF
--- a/stage/yaml/may-2025.yaml
+++ b/stage/yaml/may-2025.yaml
@@ -1,0 +1,200 @@
+- id: Monthly-Release-May25-EN
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Upgrade to Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Get monthly updates with new features and improvements in the new Thunderbird Release."
+  CTA: "Learn more"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [en-CA, en-GB, en-US],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-DE
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Upgrade auf Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Mit Thunderbird Release gibt es monatlich neue Funktionen und Verbesserungen."
+  CTA: "Mehr erfahren"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [de],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-IT
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Passa a Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Con Thunderbird Release ricevi ogni mese nuove funzionalità e miglioramenti."
+  CTA: "Scopri di più"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [it],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-JP
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Thunderbird Release にアップグレード"
+  severity: 3
+  type: message
+  description: "Thunderbird Release では毎月、新機能や改善が提供されます。"
+  CTA: "詳細はこちら"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [jp],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-FR
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Passez à Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Recevez chaque mois de nouvelles fonctionnalités et améliorations avec Thunderbird Release."
+  CTA: "En savoir plus"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [fr],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-PL
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Przejdź na Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Z Thunderbird Release co miesiąc otrzymujesz nowe funkcje i ulepszenia."
+  CTA: "Dowiedz się więcej"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [pl],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-PT-BR
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Atualize para o Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Com o Thunderbird Release, você recebe novos recursos e melhorias todo mês."
+  CTA: "Saiba mais"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [pt-BR],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-ES
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Actualiza a Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Con Thunderbird Release, recibirás nuevas funciones y mejoras cada mes."
+  CTA: "Más información"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [es],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-NL
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Upgrade naar Thunderbird Release"
+  severity: 3
+  type: message
+  description: "Met Thunderbird Release ontvang je elke maand nieuwe functies en verbeteringen."
+  CTA: "Meer informatie"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [nl],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25
+- id: Monthly-Release-May25-RU
+  start_at: 2025-05-15T00:00:00.000Z
+  end_at: 2025-08-01T00:00:00.000Z
+  title: "Обновитесь до Thunderbird Release"
+  severity: 3
+  type: message
+  description: "С Thunderbird Release вы получаете новые функции и улучшения каждый месяц."
+  CTA: "Узнать больше"
+  URL: https://support.mozilla.org/kb/choosing-thunderbird-release-channel
+  targeting:
+    include:
+      - {
+          locales: [ru],
+          versions: [128.10.1, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
+          channels: [esr],
+          pref_false: [extensions.hasExperimentsInstalled],
+        }
+    exclude:
+      - { pref_true: [browser.policies.applied] }
+    percent_chance: 25


### PR DESCRIPTION
Here is the YAML for staging which will allow us to reach ESR users on versions which include the new pref `extensions.hasExperimentsInstalled` and we'll only target users who have that set to false. We'll also be excluding anybody who has an EnterprisePolicy enabled.