### PR TITLE
cloudflare.Record requires ttl, even though documentation says it's optional

### DIFF
--- a/pulumi/__main__.py
+++ b/pulumi/__main__.py
@@ -160,13 +160,15 @@ cloudfront_distribution = aws.cloudfront.Distribution(
 )
 
 # Create a Cloudflare DNS entry pointing to the CloudFront distribution
+# Docs: https://www.pulumi.com/registry/packages/cloudflare/api-docs/record/
 dns_record = cloudflare.Record(
     'notifications_dns_record',
     zone_id=zone_id,
     name=domain_name,
     type='CNAME',
     content=cloudfront_distribution.domain_name,
-    proxied=cf_proxy
+    proxied=cf_proxy,
+    ttl=1  # 1 == automatic according to documentation
 )
 
 # Export the CloudFront distribution URL (SSL-enabled)


### PR DESCRIPTION
I ran into:

```
error: Program failed with an unhandled exception:
Traceback (most recent call last):
  File "/Users/melissaautumn/Dev/thunderbird-notifications/pulumi/__main__.py", line 163, in <module>
    dns_record = cloudflare.Record(
                 ^^^^^^^^^^^^^^^^^^
  File "/Users/melissaautumn/Dev/thunderbird-notifications/pulumi/venv/lib/python3.12/site-packages/pulumi_cloudflare/record.py", line 557, in __init__
    __self__._internal_init(resource_name, *args, **kwargs)
  File "/Users/melissaautumn/Dev/thunderbird-notifications/pulumi/venv/lib/python3.12/site-packages/pulumi_cloudflare/record.py", line 594, in _internal_init
    raise TypeError("Missing required property 'ttl'")
TypeError: Missing required property 'ttl'
```

Setting the ttl as 1 (as described in the docs for automatic ttl) seems to have worked. 

It also seems like this is a deprecated class now, and we should be using `cloudflare.index/dnsrecord.DnsRecord`. But it still works for now. 