### PR TITLE
Limit monthly upgrade notification to Windows/macOS

### DIFF
--- a/prod/yaml/may-2025.yaml
+++ b/prod/yaml/may-2025.yaml
@@ -14,6 +14,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -35,6 +36,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -56,6 +58,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -77,6 +80,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -98,6 +102,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -119,6 +124,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -140,6 +146,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -161,6 +168,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -182,6 +190,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:
@@ -203,6 +212,7 @@
           versions:
             [128.10.1, 128.10.2, 128.11.0, 128.11.1, 128.12.0, 128.12.1],
           channels: [esr],
+          operating_systems: [win, macosx],
           pref_false: [extensions.hasExperimentsInstalled],
         }
     exclude:


### PR DESCRIPTION
There are several package formats used by Linux users to install Thunderbird. Users of these packages don't have any control over switching to the Release channel. Therefore let's limit this notification to Windows and macOS to avoid confusion.