### PR TITLE
Added exclusions for the main Spring appeal and tests (fixes #93)

### DIFF
--- a/stage/yaml/esr140.yaml
+++ b/stage/yaml/esr140.yaml
@@ -27,7 +27,10 @@
           channels: [esr],
         }
     exclude:
-      - { displayed_notifications: [ESR140-B] }
+      - {
+          displayed_notifications:
+            [ESR140-B, Spring25, Spring25-Test-EN, Spring25-Test-DE],
+        }
     percent_chance: 50
 - id: ESR140-B
   start_at: 2025-06-19T00:00:00.000Z
@@ -58,5 +61,8 @@
           channels: [esr],
         }
     exclude:
-      - { displayed_notifications: [ESR140-A] }
+      - {
+          displayed_notifications:
+            [ESR140-A, Spring25, Spring25-Test-EN, Spring25-Test-DE],
+        }
     percent_chance: 100

--- a/stage/yaml/esr140.yaml
+++ b/stage/yaml/esr140.yaml
@@ -27,10 +27,10 @@
           channels: [esr],
         }
     exclude:
-      - {
-          displayed_notifications:
-            [ESR140-B, Spring25, Spring25-Test-EN, Spring25-Test-DE],
-        }
+      - { displayed_notifications: [ESR140-B] }
+      - { displayed_notifications: [Spring25] }
+      - { displayed_notifications: [Spring25-Test-EN] }
+      - { displayed_notifications: [Spring25-Test-DE] }
     percent_chance: 50
 - id: ESR140-B
   start_at: 2025-06-19T00:00:00.000Z
@@ -61,8 +61,8 @@
           channels: [esr],
         }
     exclude:
-      - {
-          displayed_notifications:
-            [ESR140-A, Spring25, Spring25-Test-EN, Spring25-Test-DE],
-        }
+      - { displayed_notifications: [ESR140-A] }
+      - { displayed_notifications: [Spring25] }
+      - { displayed_notifications: [Spring25-Test-EN] }
+      - { displayed_notifications: [Spring25-Test-DE] }
     percent_chance: 100

--- a/stage/yaml/esr140.yaml
+++ b/stage/yaml/esr140.yaml
@@ -28,9 +28,6 @@
         }
     exclude:
       - { displayed_notifications: [ESR140-B] }
-      - { displayed_notifications: [Spring25] }
-      - { displayed_notifications: [Spring25-Test-EN] }
-      - { displayed_notifications: [Spring25-Test-DE] }
     percent_chance: 50
 - id: ESR140-B
   start_at: 2025-06-19T00:00:00.000Z
@@ -62,7 +59,4 @@
         }
     exclude:
       - { displayed_notifications: [ESR140-A] }
-      - { displayed_notifications: [Spring25] }
-      - { displayed_notifications: [Spring25-Test-EN] }
-      - { displayed_notifications: [Spring25-Test-DE] }
     percent_chance: 100

--- a/stage/yaml/spring-2025.yaml
+++ b/stage/yaml/spring-2025.yaml
@@ -80,4 +80,6 @@
       - { displayed_notifications: [PREBAKED-Spring25] }
       - { displayed_notifications: [Spring25-Welcome-EN] }
       - { displayed_notifications: [Spring25-Welcome-DE] }
+      - { displayed_notifications: [ESR140-A] }
+      - { displayed_notifications: [ESR140-B] }
     percent_chance: 100


### PR DESCRIPTION
In testing, new users on ESR 140 were seeing both Spring appeal and also the new ESR140 appeal. Add exclusions to prevent