### PR TITLE
Stages the second December appeal to all remaining users

### DIFF
--- a/stage/yaml/eoy-dec2-2025.yaml
+++ b/stage/yaml/eoy-dec2-2025.yaml
@@ -94,7 +94,7 @@
       - { locales: [en-CA, en-GB, en-US]}
     percent_chance: 100
 
-  - id: EOY-Dec2-2025-BD
+- id: EOY-Dec2-2025-BD
   start_at: 2025-12-20T00:00:00.000Z
   end_at: 2026-03-01T00:00:00.000Z
   title: "EOY-Dec2-2025-BD"


### PR DESCRIPTION
Fixes #121

Opens the winning D version to 100% of users
Adds the November 6C group to get the separately tracked D version
Shows the localized D version to non English users who previously saw Dec2 A and B versions from the test (delayed until Dec 20)

